### PR TITLE
ETS backend implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ebin
 doc
 *.iml
 .rebar
+.idea

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{erl_opts, [{parse_transform, lager_transform}, {src_dirs, ["src", "test"]}, debug_info]}.
+{erl_opts, [{parse_transform, lager_transform}, debug_info]}.
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.
 {eunit_compile_opts, [{parse_transform, lager_transform}, debug_info]}.

--- a/src/zraft_backend.erl
+++ b/src/zraft_backend.erl
@@ -33,7 +33,7 @@
 -callback init(PeerId :: zraft_consensus:peer_id()) -> state().
 
 %% read/query data from FSM
--callback query(ReadCmd :: read_cmd(), State :: state()) -> {ok, Sata :: term()}.
+-callback query(ReadCmd :: read_cmd(), State :: state()) -> {ok, Data :: term()}.
 
 %% write data to FSM
 -callback apply_data(WriteCmd :: write_cmd(), State :: state()) -> {Result :: term(), State :: state()}.

--- a/src/zraft_backend.erl
+++ b/src/zraft_backend.erl
@@ -24,19 +24,20 @@
 -export([]).
 
 -type state() :: term().
--type read_cmd()::term().
--type write_cmd()::term().
--type snapshot_fun()::fun((Dest :: file:filename()) -> ok | {error, Reason :: term()}).
-
+-type read_cmd() :: term().
+-type write_cmd() :: term().
+-type snapshot_fun() :: fun((Dest :: file:filename()) -> ok | {error, Reason :: term()}).
+-type kv() :: {Key :: term(), Value :: term()}.
 
 %% init backend FSM
 -callback init(PeerId :: zraft_consensus:peer_id()) -> state().
 
 %% read/query data from FSM
--callback query(ReadCmd :: read_cmd(), State :: state()) -> {ok, Data :: term()}.
+-callback query(ReadCmd :: read_cmd(), State :: state()) -> {ok, Data :: [kv()]}.
 
 %% write data to FSM
--callback apply_data(WriteCmd :: write_cmd(), State :: state()) -> {Result :: term(), State :: state()}.
+-callback apply_data(WriteCmd :: write_cmd(), State :: state()) -> {Result, State :: state()}
+    when Result :: {ok, Keys :: [term()]} | {error, Reason :: term()}.
 
 %% Prepare FSM to take snapshot async if it's possible otherwice return function to take snapshot immediatly
 -callback snapshot(State :: state())->{sync, snapshot_fun(), state()} | {async, snapshot_fun(), state()}.

--- a/src/zraft_backend.erl
+++ b/src/zraft_backend.erl
@@ -39,7 +39,7 @@
 -callback apply_data(WriteCmd :: write_cmd(), State :: state()) -> {Result :: term(), State :: state()}.
 
 %% Prepare FSM to take snapshot async if it's possible otherwice return function to take snapshot immediatly
--callback snapshot(State :: state())->{sync,snapshot_fun()} | {async,snapshot_fun()}.
+-callback snapshot(State :: state())->{sync, snapshot_fun(), state()} | {async, snapshot_fun(), state()}.
 
 %% Notify that snapshot has done.
 -callback snapshot_done(State :: state())->{ok, NewState :: state()}.

--- a/src/zraft_backend.erl
+++ b/src/zraft_backend.erl
@@ -26,7 +26,7 @@
 -type state() :: term().
 -type read_cmd()::term().
 -type write_cmd()::term().
--type snapshot_fun()::fun().
+-type snapshot_fun()::fun((Dest :: file:filename()) -> ok | {error, Reason :: term()}).
 
 
 %% init backend FSM

--- a/src/zraft_backend.erl
+++ b/src/zraft_backend.erl
@@ -30,22 +30,22 @@
 
 
 %% init backend FSM
--callback init(zraft_consensus:peer_id()) -> state().
+-callback init(PeerId :: zraft_consensus:peer_id()) -> state().
 
 %% read/query data from FSM
--callback query(read_cmd(),state()) -> {ok,term()}.
+-callback query(ReadCmd :: read_cmd(), State :: state()) -> {ok, Sata :: term()}.
 
 %% write data to FSM
--callback apply_data(write_cmd(),state()) -> {term(),state()}.
+-callback apply_data(WriteCmd :: write_cmd(), State :: state()) -> {Result :: term(), State :: state()}.
 
-%% Prepare FSM to take snapshot asycn if it's possible otherwice return function to take snapshot immediatly
--callback snapshot(state())->{sync,snapshot_fun()} | {async,snapshot_fun()}.
+%% Prepare FSM to take snapshot async if it's possible otherwice return function to take snapshot immediatly
+-callback snapshot(State :: state())->{sync,snapshot_fun()} | {async,snapshot_fun()}.
 
 %% Notify that snapshot has done.
--callback snapshot_done(state())->{ok,state()}.
+-callback snapshot_done(State :: state())->{ok, NewState :: state()}.
 
 %% Notify that snapshot has failed.
--callback snapshot_failed(Reason::term(),state())->{ok,state()}.
+-callback snapshot_failed(Reason :: term(), State :: state())->{ok,state()}.
 
 %% Read data from snapshot file or directiory.
--callback install_snapshot(file:filename(),state())->{ok,state()}.
+-callback install_snapshot(FileName :: file:filename(), State :: state())->{ok,state()}.

--- a/src/zraft_backend.erl
+++ b/src/zraft_backend.erl
@@ -48,4 +48,4 @@
 -callback snapshot_failed(Reason :: term(), State :: state())->{ok,state()}.
 
 %% Read data from snapshot file or directiory.
--callback install_snapshot(FileName :: file:filename(), State :: state())->{ok,state()}.
+-callback install_snapshot(FileName :: file:filename(), State :: state())-> {ok,state()} | {error, Reason :: term}.

--- a/src/zraft_dict_backend.erl
+++ b/src/zraft_dict_backend.erl
@@ -49,7 +49,7 @@ apply_data(List,Dict) when is_list(List)->
         dict:store(K,V,Acc) end,Dict,List),
     {ok,Dict1}.
 
-%% @doc Prepare FSM to take snapshot asycn if it's possible otherwice return function to take snapshot immediatly
+%% @doc Prepare FSM to take snapshot async if it's possible otherwice return function to take snapshot immediatly
 snapshot(Dict)->
     Fun = fun(ToDir)->
         File = filename:join(ToDir,"state"),

--- a/src/zraft_ets_backend.erl
+++ b/src/zraft_ets_backend.erl
@@ -40,7 +40,7 @@ query({get, Key}, #state{ets_ref = Tab}) ->
         [Object] ->
             Object;
         [] ->
-            {ok, not_found}
+            not_found
     end,
     {ok, Result};
 

--- a/src/zraft_ets_backend.erl
+++ b/src/zraft_ets_backend.erl
@@ -1,0 +1,93 @@
+%%-------------------------------------------------------------------
+%% @author lol4t0
+%% @copyright (C) 2015
+%% @doc
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(zraft_ets_backend).
+-author("lol4t0").
+-behaviour(zraft_backend).
+
+%% API
+-export([init/1, query/2, apply_data/2, snapshot/1, snapshot_done/1, snapshot_failed/2, install_snapshot/2]).
+
+-record(state, {
+    ets_ref :: ets:tab()
+}).
+
+-define(STATE_FILENAME, "state").
+
+init(_PeerId) ->
+    #state{
+        ets_ref = ets:new(undefined, [set, protected])
+    }.
+
+query({get, Key}, #state{ets_ref = Tab}) ->
+    Result = case ets:lookup(Tab, Key) of
+        [Object] ->
+            Object;
+        [] ->
+            {ok, not_found}
+    end,
+    {ok, Result};
+
+%% Pattern is match spec
+query({list, Pattern}, #state{ets_ref = Tab}) when is_list(Pattern)->
+    {ok, ets:select(Tab, Pattern)};
+
+%% Pattern is match pattern
+query({list, Pattern}, #state{ets_ref = Tab}) when is_tuple(Pattern) orelse is_atom(Pattern) ->
+    {ok, ets:match(Tab, Pattern)};
+
+%% Pattern is function
+query(SelectFun, #state{ets_ref = Tab}) when is_function(SelectFun) ->
+    {ok, SelectFun(ets:tab2list(Tab))};
+
+query(_, _State) ->
+    {ok, {error, invalid_request}}.
+
+
+apply_data({put, Data}, State = #state{ets_ref = Tab}) ->
+    Result = ets:insert(Tab, Data),
+    {Result, State};
+apply_data({add, Data}, State = #state{ets_ref = Tab}) ->
+    Result = ets:insert_new(Tab, Data),
+    {Result, State};
+apply_data(_, State) ->
+    {{error, invalid_request}, State}.
+
+snapshot(State = #state{ets_ref = Tab}) ->
+    SaveFun = fun(Dest) ->
+        File = filename:join(Dest, ?STATE_FILENAME),
+        ets:tab2file(Tab, File, [{extended_info, [md5sum]}])
+    end,
+    {async, SaveFun, State}.
+
+snapshot_done(State) ->
+    {ok, State}.
+
+snapshot_failed(_Reason, State) ->
+    {ok, State}.
+
+install_snapshot(Dir, State = #state{ets_ref = OldTab}) ->
+    File = filename:join(Dir, ?STATE_FILENAME),
+    case ets:file2tab(File, [{verify,true}]) of
+        {ok, NewTab} ->
+            ets:delete(OldTab),
+            {ok, State#state{ets_ref = NewTab}};
+        Else ->
+            Else
+    end.

--- a/src/zraft_ets_backend.erl
+++ b/src/zraft_ets_backend.erl
@@ -317,7 +317,11 @@ test_append(Ets) ->
 
         ?assertMatch({ok, {"3", [{"3", 2}, {"3", 1}, {"3", 0}]}}, query({get, "3"}, Ets)),
         ?assertMatch({ok, {{"3", 2}, "v33"}}, query({get, {"3", 2}}, Ets)),
-        ?assertMatch({{ok, [{"3", 2}, "3"]}, Ets}, apply_data({delete, [{"3", 2}]}, Ets))
+        ?assertMatch({{ok, [{"3", 2}, "3"]}, Ets}, apply_data({delete, [{"3", 2}]}, Ets)),
+        ?assertMatch({ok, {"3", [{"3", 1}, {"3", 0}]}}, query({get, "3"}, Ets)),
+        ?assertMatch({ok, not_found}, query({get, {"3", 2}}, Ets)),
+        ?assertMatch({{ok, [{"3", 3}, "3"]}, Ets}, apply_data({append, {"3", "v4"}}, Ets)),
+        ?assertMatch({ok, {"3", [{"3", 3}, {"3", 1}, {"3", 0}]}}, query({get, "3"}, Ets))
     end.
 
 test_snapshot(Ets = #state{ets_ref = Tab}) ->

--- a/src/zraft_ets_backend.erl
+++ b/src/zraft_ets_backend.erl
@@ -35,7 +35,8 @@
     value :: term(),
     counter = 0 :: non_neg_integer(),
     mode = object :: object | group,
-    group = [] :: [term()] | []
+    group = [] :: [term()] | [],
+    sessionid :: term() %% reserved for sessioned keys.
 }).
 
 -record(find_keys_acc, {

--- a/src/zraft_ets_backend.erl
+++ b/src/zraft_ets_backend.erl
@@ -63,7 +63,7 @@ query(_, _State) ->
 apply_data({put, Data}, State = #state{ets_ref = Tab}) ->
     Result = ets:insert(Tab, Data),
     {Result, State};
-apply_data({add, Data}, State = #state{ets_ref = Tab}) ->
+apply_data({append, Data}, State = #state{ets_ref = Tab}) ->
     Result = ets:insert_new(Tab, Data),
     {Result, State};
 apply_data({delete, Keys}, State = #state{ets_ref = Tab}) when is_list(Keys) ->
@@ -136,14 +136,14 @@ test_empty_get(Ets) ->
 test_put(Ets) ->
     fun() ->
         ?assertMatch({true, Ets}, apply_data({put, {["/", "1"], "v1"}}, Ets)),
-        ?assertMatch({false, Ets}, apply_data({add, {["/", "1"], "v1"}}, Ets)),
+        ?assertMatch({false, Ets}, apply_data({append, {["/", "1"], "v1"}}, Ets)),
         ?assertMatch({true, Ets}, apply_data({delete, [["/", "1"]]}, Ets)),
-        ?assertMatch({true, Ets}, apply_data({add, {["/", "1"], "v1"}}, Ets)),
+        ?assertMatch({true, Ets}, apply_data({append, {["/", "1"], "v1"}}, Ets)),
         ?assertMatch({true, Ets}, apply_data({put, [
             {["/", "1"], "v1"},
             {["/", "2", "3"], "v2"}
         ]}, Ets)),
-        ?assertMatch({false, Ets}, apply_data({add, [
+        ?assertMatch({false, Ets}, apply_data({append, [
             {["/", "1"], "v1"},
             {["/", "3"], "v3"}
         ]}, Ets)),

--- a/src/zraft_ets_backend.erl
+++ b/src/zraft_ets_backend.erl
@@ -173,14 +173,14 @@ apply_data_unsafe({put_new, Data}, State = #state{ets_ref = Tab}) ->
 apply_data_unsafe({delete, Keys}, State = #state{ets_ref = Tab}) when is_list(Keys) ->
     #find_keys_acc{keys = AllKeys, group_keys = AllGroups} = find_keys_recursive(Tab, Keys, #find_keys_acc{}),
     lists:foreach(fun(Key) -> ets:delete(Tab, Key) end, AllKeys),
-    AcrtiveGroups = orddict:filter(fun(K, _V) -> not lists:member(K, AllKeys) end, AllGroups),
+    ActiveGroups = orddict:filter(fun(K, _V) -> not lists:member(K, AllKeys) end, AllGroups),
     orddict:map(
         fun(K, RemovedChildren) ->
             #item{mode = group, value = Children} = I = hd(ets:lookup(Tab, K)),
             NewI = I#item{value = Children -- RemovedChildren},
             true = ets:insert(Tab, NewI)
-        end, AcrtiveGroups),
-    {{ok, AllKeys ++ orddict:fetch_keys(AcrtiveGroups)}, State};
+        end, ActiveGroups),
+    {{ok, AllKeys ++ orddict:fetch_keys(ActiveGroups)}, State};
 apply_data_unsafe({increment, Key, Incr}, State = #state{ets_ref = Tab}) ->
     NewVal = ets:update_counter(Tab, Key, Incr),
     {NewVal, State};

--- a/src/zraft_snapshot_writer.erl
+++ b/src/zraft_snapshot_writer.erl
@@ -163,7 +163,7 @@ setup() ->
     zraft_util:make_dir(?DATA_DIR),
     ok.
 clear_setup(_) ->
-    zraft_util:del_dir(?DATA_DIR),
+    %%zraft_util:del_dir(?DATA_DIR),
     ok.
 
 write_snapshot_test_() ->
@@ -206,8 +206,9 @@ write() ->
                 ?assert(false)
         end,
         Res = zip:unzip(ResultFile),
-        ?assertMatch({ok,["test-snaphot/dump-1/info",
-            "test-snaphot/dump-1/data/dump"]},Res),
+        ?assertMatch({ok, [_, _]}, Res),
+        {ok, ResData} = Res,
+        ?assertMatch(["test-snaphot/dump-1/data/dump", "test-snaphot/dump-1/info"], lists:sort(ResData)),
         {ok,SInfo} = read_snapshot_info("test-snaphot/dump-1"),
         ?assertMatch(#snapshot_info{index = 10,conf = [],term = 1,conf_index = 1},SInfo),
         {ok,C2} = file:read_file("test-snaphot/dump-1/data/dump"),


### PR DESCRIPTION
# Features

## Multi-version elements

Multi-version elements represent a group of items with the same _group key_ but different _concrete keys_.

Multi-version element is added with write command `append`. Command fomat is

```erlang
{append, [{GroupKey :: term(), Value :: term()}]}
```

This request creates group key for every `GroupKey` and concrete key `{GroupKey, Version :: term()}`.  Values saved for concrete keys.

List of group key along with concrete key is returned as a result of request.

## Query

* get query

```erlang
{get, Key :: term()}
```
Returns element with the given Key. List of concrete keys is returned as a value of element if key is group key.

* list query
```erlang
{list, Pattern :: ets:match_pattern()}
```
Returns list of elements with keys _matching_ given Pattern

* fold query
```erlang
{fold, SelectFunction, Acc :: term()} when 
    SelectFunction :: fun((Key :: term(), Value :: term(), Acc :: term()) -> term())
```
Executes specified function on data. 

## Apply data

* put command
```erlang
{put, [Data :: {Key :: term(), Value :: term()]}
```
Saves or replaces data. Returns list of keys of updated elements. Group elements cannot be replaced with ordinary.

* put_new
```erlang
{put, [Data :: {Key :: term(), Value :: term()]}
```
Only saves new data. Returns list of keys of updated elements.

* append
```erlang
{append, [{GroupKey :: term(), Value :: term()}]}
```

* delete
```erlang
{delete, [Key::term()] }
```
Deletes data by specified keys. Group items deleted recursively. Returns list of keys of updated elements (i.e. deleted keys and keys of updated group items)

* increment
```erlang
{increment, Key :: term(), Increment :: integer()}
```
Increments value (considered numeric) by the specified key. 
