### PR TITLE
refactors out case expression

### DIFF
--- a/src/zraft_lib_app.erl
+++ b/src/zraft_lib_app.erl
@@ -29,12 +29,7 @@
 ]).
 
 start(_StartType, _StartArgs) ->
-    case zraft_lib_sup:start_link() of
-        {ok, Pid} ->
-            {ok, Pid};
-        Error ->
-            Error
-    end.
+    zraft_lib_sup:start_link().
 
 stop(_State) ->
     ok.


### PR DESCRIPTION
This case expression is not needed since each branch returns the same value the `zraft_lib_sup:start_link/0` function returns