### PR TITLE
Add functions for stopping and deleting peers

### DIFF
--- a/src/zraft_consensus.erl
+++ b/src/zraft_consensus.erl
@@ -656,7 +656,9 @@ handle_sync_event(force_timeout, From, StateName, State) ->
                     ?MODULE:StateName(timeout, State#state{timer = undefined})
             end
     end;
-
+handle_sync_event({set_trap_exit, Flag}, _From, StateName, State) ->
+    process_flag(trap_exit, Flag),
+    {reply, ok, StateName, State};
 %% drop unknown
 handle_sync_event(_Event, _From, StateName, State) ->
     Error = list_to_atom(atom_to_list(StateName) ++ "_not_supported"),

--- a/src/zraft_lib_sup.erl
+++ b/src/zraft_lib_sup.erl
@@ -24,7 +24,7 @@
 
 -export([start_link/0]).
 
--export([init/1,start_consensus/2,start_consensus/1]).
+-export([init/1,start_consensus/2,start_consensus/1,stop_consensus/1]).
 
 -include("zraft.hrl").
 
@@ -53,6 +53,11 @@ start_consensus(PeerID,BackEnd)->
 start_consensus(PeerID)->
     Spec = consensus_spec([PeerID]),
     start_result(supervisor:start_child(?MODULE, Spec)).
+
+-spec stop_consensus(zraft_consensus:peer_id()) -> ok | {error, atom()}.
+stop_consensus(PeerID)->
+    supervisor:terminate_child(?MODULE, PeerID),
+    supervisor:delete_child(?MODULE, PeerID).
 
 start_result({ok,P})->
     {ok,P};

--- a/test/delete_peers.erl
+++ b/test/delete_peers.erl
@@ -1,0 +1,34 @@
+%%%-------------------------------------------------------------------
+%%% @author ashirko
+%%% @copyright (C) 2019, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 23. Окт. 2019 15:57
+%%%-------------------------------------------------------------------
+-module(delete_peers).
+-author("ashirko").
+
+-include_lib("eunit/include/eunit.hrl").
+
+delete_peers_test() ->
+    PeerID1 = {test_delete1, node()},
+    PeerID2 = {test_delete2, node()},
+    PeerID3 = {test_delete3, node()},
+    Peers = [PeerID1, PeerID2, PeerID3],
+    %%  check that peers do not exist before creation
+    lists:foreach(fun(P) ->
+        ?assertEqual(ok,zraft_client:check_exists(P))
+                  end, Peers),
+    {ok, _} = zraft_lib_sup:start_link(),
+    ?assertEqual({ok, Peers}, zraft_client:create(Peers,zraft_dict_backend)),
+    %%  check that peers were created successfully
+    lists:foreach(fun(P) ->
+        ?assertEqual({error, already_present},zraft_client:check_exists(P))
+                  end, Peers),
+    ok = zraft_client:delete(Peers),
+    %%  check that peers were deleted successfully
+    lists:foreach(fun(P) ->
+        ?assertEqual(ok,zraft_client:check_exists(P))
+                  end, Peers).
+


### PR DESCRIPTION
Function zraft_client:delete/1 stops peers processes and deletes corresponding files from disk.
Set flag trap_exit to 'true' for zraft_consensus process for trapping exit signal from supervisor and stopping corresponding processes correctly.
Resolve #25